### PR TITLE
No duplicate user emails

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,6 +30,7 @@ class UsersController < ApplicationController
 
 
   def update
+    flash[:message]
     current_user.update(user_params)
     redirect_to profile_path
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -30,9 +30,13 @@ class UsersController < ApplicationController
 
 
   def update
-    flash[:message]
-    current_user.update(user_params)
-    redirect_to profile_path
+    if User.find_by(email: params[:user][:email])
+      flash[:message] = "That email is already in use"
+      redirect_to profile_edit_path
+    else
+      current_user.update(user_params)
+      redirect_to profile_path
+    end
   end
 
   private

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,4 +1,4 @@
-<%= form_for @user, method: "put" do |f| %>
+<%= form_for @user, url: users_path, method: "put" do |f| %>
 <%= f.label :name %>
 <%= f.text_field :name %>
 <%= f.label :email %>

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -41,14 +41,14 @@ describe "as a user" do
     end
 
     it "does not let me enter a used email in profile edit" do
-      @user_1 = User.create(email: "bob@bob.com", password_digest: 1243, name: "bob", address:"123 bob st.", city: "bobton", state:"MA", zip: 28234)
-      @user_2 = User.create(email: "george@bob.com", password_digest: 1243, name: "george", address:"123 george st.", city: "georgeton", state:"MA", zip: 28234)
+      @user_1 = User.create!(email: "bob@bob.com", password: "123dd43", name: "bob", address:"123 bob st.", city: "bobton", state:"MA", zip: 28234)
+      @user_2 = User.create!(email: "george@bob.com", password: "124344", name: "george", address:"123 george st.", city: "georgeton", state:"MA", zip: 28234)
         allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
         visit profile_edit_path
         fill_in 'user_email', with: @user_2.email
         click_button "Change my Profile"
         expect(current_path).to eq(profile_edit_path)
-        expect(page).to have_content("That email is in use")
+        expect(page).to have_content("That email is already in use")
     end
 
 #     As a registered user

--- a/spec/features/users/edit_spec.rb
+++ b/spec/features/users/edit_spec.rb
@@ -40,6 +40,24 @@ describe "as a user" do
 
     end
 
+    it "does not let me enter a used email in profile edit" do
+      @user_1 = User.create(email: "bob@bob.com", password_digest: 1243, name: "bob", address:"123 bob st.", city: "bobton", state:"MA", zip: 28234)
+      @user_2 = User.create(email: "george@bob.com", password_digest: 1243, name: "george", address:"123 george st.", city: "georgeton", state:"MA", zip: 28234)
+        allow_any_instance_of(ApplicationController).to receive(:current_user).and_return(@user_1)
+        visit profile_edit_path
+        fill_in 'user_email', with: @user_2.email
+        click_button "Change my Profile"
+        expect(current_path).to eq(profile_edit_path)
+        expect(page).to have_content("That email is in use")
+    end
+
+#     As a registered user
+# When I attempt to edit my profile data
+# If I try to change my email address to one that belongs to another user
+# When I submit the form
+# Then I am returned to the profile edit page
+# And I see a flash message telling me that email address is already in use
+
   end
 
 end


### PR DESCRIPTION
This PR

-Ensures users cant edit their email to an existing users email by
-modifying users update controller action
-adding test
-changing path on user edit form