### PR TITLE
Admin Navigation

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,3 @@
+class Admin::BaseController < ApplicationController
+  
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,3 @@
+class Admin::DashboardController < Admin::BaseController
+
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,3 +1,5 @@
 class Admin::DashboardController < Admin::BaseController
-
+  def index
+    
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,7 +17,9 @@
       <%= link_to "LogIn", login_path unless current_user %>
       <%= link_to "Register", register_path unless current_user %>
       <%= link_to "Cart", cart_path if (current_user && !current_user.merchant? && !current_user.admin?) || !current_user %>
-      <p> <%= pluralize(cart.quantity, "Item") %> in cart</p>
+      <% if (current_user && !current_user.merchant? && !current_user.admin?) || !current_user %>
+        <p> <%= pluralize(cart.quantity, "Item") %> in cart</p>
+      <% end %>
       <%= link_to "Profile", profile_path if current_user %>
       <%= link_to "Logout", logout_path, method: "delete" if current_user %>
       <%= link_to "Dashboard", dashboard_path if current_user && current_user.merchant? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,11 +16,12 @@
       <%= link_to "Merchants", merchants_path %>
       <%= link_to "LogIn", login_path unless current_user %>
       <%= link_to "Register", register_path unless current_user %>
-      <%= link_to "Cart", cart_path if (current_user && !current_user.merchant?) || !current_user %>
+      <%= link_to "Cart", cart_path if (current_user && !current_user.merchant? && !current_user.admin?) || !current_user %>
       <p> <%= pluralize(cart.quantity, "Item") %> in cart</p>
       <%= link_to "Profile", profile_path if current_user %>
       <%= link_to "Logout", logout_path, method: "delete" if current_user %>
       <%= link_to "Dashboard", dashboard_path if current_user && current_user.merchant? %>
+      <%= link_to "Dashboard", admin_dashboard_path if current_user && current_user.admin? %>
     </section>
 
     <section class="flash">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,5 +22,6 @@ Rails.application.routes.draw do
   delete '/logout', to: "sessions#delete"
 
   get '/dashboard', to: "merchants#show"
-
+  
+  get 'admin/dashboard', to: 'dashboard#index'
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -22,6 +22,8 @@ Rails.application.routes.draw do
   delete '/logout', to: "sessions#delete"
 
   get '/dashboard', to: "merchants#show"
-  
-  get 'admin/dashboard', to: 'dashboard#index'
+
+  namespace :admin do
+    get '/dashboard', to: 'dashboard#index'
+  end
 end

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -2,33 +2,39 @@ require 'rails_helper'
 
 ###Tests for navbar showing number of items in cart are in cart_show reature spec
 
-describe "as a visitor" do
-  describe "when I visit the welcome page" do
+RSpec.describe "when I visit the welcome page" do
+  context "as a visitor" do
     it "it displays a navigation bar" do
       visit root_path
 
       within ".navbar" do
         click_link("Home")
         expect(current_path).to eq(root_path)
+
         click_link("Items")
         expect(current_path).to eq(items_path)
+
         click_link("Merchants")
         expect(current_path).to eq(merchants_path)
+
         click_link("Cart")
         expect(current_path).to eq(cart_path)
+
         click_link("LogIn")
         expect(current_path).to eq(login_path)
+
         click_link("Register")
         expect(current_path).to eq(register_path)
       end
     end
   end
 
-describe "as a registered user" do
+  context "as a registered user" do
     it "lets a user log out" do
-      user = User.create!(email: "bob@bob.com", password: "124355",
-        name: "bob", address:"123 bob st.", city: "bobton", state:"MA", zip: 28234)
+      user = User.create!(email: "bob@bob.com", password: "124355", name: "bob", address:"123 bob st.", city: "bobton", state:"MA", zip: 28234)
+
       visit root_path
+
       click_on "LogIn"
       fill_in "email", with: user.email
       fill_in "password", with: user.password
@@ -36,32 +42,40 @@ describe "as a registered user" do
 
       within ".navbar" do
         click_link("Logout")
+
         expect(current_path).to eq(root_path)
       end
       expect(page).to have_content("You are now logged Out")
     end
 
-      it "gives me different options as a user" do
-        user = User.create!(email: "bob@bob.com", password: "124355",
-          name: "bob", address:"123 bob st.", city: "bobton", state:"MA", zip: 28234)
-        visit root_path
-        click_on "LogIn"
-        fill_in "email", with: user.email
-        fill_in "password", with: user.password
-        click_on "Log In"
-        within ".navbar" do
+    it "gives me different options as a user" do
+      user = User.create!(email: "bob@bob.com", password: "124355", name: "bob", address:"123 bob st.", city: "bobton", state:"MA", zip: 28234)
+
+      visit root_path
+
+      click_on "LogIn"
+      fill_in "email", with: user.email
+      fill_in "password", with: user.password
+      click_on "Log In"
+
+      within ".navbar" do
         click_link("Home")
         expect(current_path).to eq(root_path)
+
         click_link("Items")
         expect(current_path).to eq(items_path)
+
         click_link("Merchants")
         expect(current_path).to eq(merchants_path)
+
         click_link("Cart")
         expect(current_path).to eq(cart_path)
         expect(page).to_not have_link("LogIn")
         expect(page).to_not have_link("Register")
+
         click_link("Profile")
         expect(current_path).to eq(profile_path)
+
         click_link("Logout")
         expect(current_path).to eq(root_path)
         expect(page).to have_link("LogIn")
@@ -70,53 +84,85 @@ describe "as a registered user" do
     end
 
     it "directs to a users profile if already logged in" do
-      user = User.create!(email: "bob@bob.com", password: "124355",
-        name: "bob", address:"123 bob st.", city: "bobton", state:"MA", zip: 28234)
+      user = User.create!(email: "bob@bob.com", password: "124355", name: "bob", address:"123 bob st.", city: "bobton", state:"MA", zip: 28234)
+
       visit root_path
+
       click_on "LogIn"
       fill_in "email", with: user.email
       fill_in "password", with: user.password
       click_on "Log In"
       visit "/login"
+
       expect(current_path).to eq(profile_path)
     end
   end
-end
 
-  describe "as a merchant" do
+  context "as a merchant" do
     before :each do
       @merchant = User.create!(email: "joe@joe.com", password: "124355",
         name: "joe", role: 1, address:"123 joe st.", city: "joeton", state:"MI", zip: 28334)
-        visit root_path
-        click_on "LogIn"
-        fill_in "email", with: @merchant.email
-        fill_in "password", with: @merchant.password
-        click_on "Log In"
+
+      visit root_path
+
+      click_on "LogIn"
+      fill_in "email", with: @merchant.email
+      fill_in "password", with: @merchant.password
+      click_on "Log In"
     end
+
     it "shows me the same links as a visitor" do
       click_link("Home")
       expect(current_path).to eq(root_path)
+
       click_link("Items")
       expect(current_path).to eq(items_path)
+
       click_link("Merchants")
       expect(current_path).to eq(merchants_path)
     end
 
     it "also shows the logout and dashboard" do
-        visit root_path
+      visit root_path
+
       click_link("Dashboard")
       expect(current_path).to eq(dashboard_path)
+
       click_link("Logout")
       expect(current_path).to eq(root_path)
     end
 
     it "doesnt show login/register or cart" do
       visit root_path
+
       expect(page).to_not have_link("LogIn")
       expect(page).to_not have_link("Register")
       expect(page).to_not have_link("Cart")
     end
   end
+
+  context "as an admin" do
+    before :each do
+      @admin = User.create!(email: "admin@gmail.com", password: "124356", name: "Admin", role: 2, address: "Admin Address", city: "Admin City", state: "MA", zip: 28334)
+
+      visit root_path
+
+      click_on "LogIn"
+      fill_in "email", with: @admin.email
+      fill_in "password", with: @admin.password
+      click_on "Log In"
+    end
+
+    it "the page doesn't display a link to my cart or item count" do
+      visit root_path
+
+      within ".navbar" do
+        expect(page).to_not have_link("Cart")
+        expect(page).to_not have_content("Items in cart")
+      end
+    end
+  end
+end
 
 #   As a merchant user
 # I see the same links as a visitor

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -161,6 +161,18 @@ RSpec.describe "when I visit the welcome page" do
         expect(page).to_not have_content("Items in cart")
       end
     end
+
+    it "the page displays a link to my admin dashboard" do
+      visit root_path
+
+      within ".navbar" do
+        expect(page).to have_link("Dashboard")
+
+        click_link("Dashboard")
+
+        expect(current_path).to eq(admin_dashboard_path)
+      end
+    end
   end
 end
 


### PR DESCRIPTION
This PR adds admin navigation to the nav bar.

- Admin::BaseController and Admin::DashboardController have been added
- Admin::DashboardController index action and view have been added
- Admin will not see a link to a cart or count of cart items on the nav bar (this has also been resolved for the merchant)
- Refactor Welcome index spec for readability, add additional admin specs