### PR TITLE
Admin Users Index

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,3 +1,9 @@
 class Admin::BaseController < ApplicationController
-  
+  before_action :require_admin
+
+  private
+
+  def require_admin
+    render file: "/public/404", status: 404 unless current_admin?
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,5 @@
+class Admin::UsersController < Admin::BaseController
+  def index
+    
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UsersController < Admin::BaseController
   def index
-    
+    @default_users = User.find_default_users
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
-  helper_method :current_user, :user_is_merchant?, :cart
+
+  helper_method :current_user, :user_is_merchant?, :cart, :current_admin?
 
   def cart
     @cart ||= Cart.new(session[:cart])
@@ -8,5 +9,11 @@ class ApplicationController < ActionController::Base
 
   def current_user
     @current_user ||= User.find(session[:user_id]) if session[:user_id]
+  end
+
+  private
+
+  def current_admin?
+    current_user && current_user.admin?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,10 @@ class User < ApplicationRecord
   validates :email, presence: true, uniqueness: true
   validates :password, presence: true, length: (6..51)
 
+  def self.find_default_users
+    where(role: "default")
+  end
+
   def self.find_merchants
     where(role: "merchant")
   end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -3,7 +3,8 @@
 <section class="all-default-users">
   <% @default_users.each do |user| %>
     <div class="default-user-<%= user.id %>">
-      <p><%= link_to user.name, admin_user_path(user) %> Joined: <%= user.created_at %>
+      <p><%= link_to user.name, admin_user_path(user) %> Joined: <%= user.created_at %></p>
+      <%= button_to "Upgrade to Merchant" %>
     </div>
   <% end %>
 </section>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -2,6 +2,8 @@
 
 <section class="all-default-users">
   <% @default_users.each do |user| %>
-    <%= link_to user.name, admin_user_path(user) %>
+    <div class="default-user-<%= user.id %>">
+      <p><%= link_to user.name, admin_user_path(user) %> Joined: <%= user.created_at %>
+    </div>
   <% end %>
 </section>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,7 @@
+<h2>All Default Users</h2>
+
+<section class="all-default-users">
+  <% @default_users.each do |user| %>
+    <%= link_to user.name, admin_user_path(user) %>
+  <% end %>
+</section>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,6 +24,7 @@
       <%= link_to "Logout", logout_path, method: "delete" if current_user %>
       <%= link_to "Dashboard", dashboard_path if current_user && current_user.merchant? %>
       <%= link_to "Dashboard", admin_dashboard_path if current_user && current_user.admin? %>
+      <%= link_to "Users", admin_users_path if current_user && current_user.admin? %>
     </section>
 
     <section class="flash">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -32,6 +32,6 @@ Rails.application.routes.draw do
   namespace :admin do
     get '/dashboard', to: 'dashboard#index'
 
-    resources :users, only: [:index]
+    resources :users, only: [:index, :show]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get '/dashboard', to: 'dashboard#index'
+    get '/dashboard/:id', to: 'merchants#show', as: :merchant_path
 
     resources :users, only: [:index, :show]
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,5 +31,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get '/dashboard', to: 'dashboard#index'
+
+    resources :users, only: [:index]
   end
 end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe "as an admin" do
       @admin_2 = User.create!(email: "admin_2@gmail.com", role: 2, name: "Admin 2", address: "Admin 2 Address", city: "Admin 2 City", state: "Admin 2 State", zip: "22345", password: "123456")
       @merchant_1 = User.create!(email: "merchant_1@gmail.com", role: 1, name: "Merchant 1", address: "Merchant 1 Address", city: "Merchant 1 City", state: "Merchant 1 State", zip: "32345", password: "123456")
       @merchant_2 = User.create!(email: "merchant_2@gmail.com", role: 1, name: "Merchant 2", address: "Merchant 2 Address", city: "Merchant 2 City", state: "Merchant 2 State", zip: "42345", password: "123456")
-      @user_1 = User.create!(email: "user_1@gmail.com", role: 0, name: "User 1", address: "User 1 Address", city: "User 1 City", state: "User 1 State", zip: "52345", password: "123456")
-      @user_2 = User.create!(email: "user_2@gmail.com", role: 0, name: "User 2", address: "User 2 Address", city: "User 2 City", state: "User 2 State", zip: "62345", password: "123456")
-      @user_3 = User.create!(email: "user_3@gmail.com", role: 0, name: "User 3", address: "User 3 Address", city: "User 3 City", state: "User 3 State", zip: "72345", password: "123456")
-      @user_4 = User.create!(email: "user_4@gmail.com", role: 0, name: "User 4", address: "User 4 Address", city: "User 4 City", state: "User 4 State", zip: "82345", password: "123456")
+      @user_1 = User.create!(email: "user_1@gmail.com", role: 0, name: "User 1", address: "User 1 Address", city: "User 1 City", state: "User 1 State", zip: "52345", password: "123456", created_at: 4.days.ago)
+      @user_2 = User.create!(email: "user_2@gmail.com", role: 0, name: "User 2", address: "User 2 Address", city: "User 2 City", state: "User 2 State", zip: "62345", password: "123456", created_at: 3.days.ago)
+      @user_3 = User.create!(email: "user_3@gmail.com", role: 0, name: "User 3", address: "User 3 Address", city: "User 3 City", state: "User 3 State", zip: "72345", password: "123456", created_at: 2.days.ago)
+      @user_4 = User.create!(email: "user_4@gmail.com", role: 0, name: "User 4", address: "User 4 Address", city: "User 4 City", state: "User 4 State", zip: "82345", password: "123456", created_at: 1.days.ago)
 
       visit root_path
 
@@ -33,7 +33,7 @@ RSpec.describe "as an admin" do
 
     it "I see each user's name as a link to a show page for that user" do
       visit admin_users_path
-      
+
       within ".all-default-users" do
         expect(page).to have_link(@user_1.name)
         expect(page).to have_link(@user_2.name)
@@ -42,12 +42,28 @@ RSpec.describe "as an admin" do
       end
     end
 
-    # it "I see the date each user registered beside their name" do
-    #
-    # end
-    #
-    # it "I see an 'Upgrade to Merchant' button beside each user name" do
-    #
-    # end
+    it "I see the date each user registered beside their name" do
+      visit admin_users_path
+
+      within ".all-default-users" do
+        within ".default-user-#{@user_1.id}" do
+          expect(page).to have_content("Joined: #{@user_1.created_at}")
+        end
+
+        within ".default-user-#{@user_2.id}" do
+          expect(page).to have_content("Joined: #{@user_2.created_at}")
+        end
+
+        within ".default-user-#{@user_3.id}" do
+          expect(page).to have_content("Joined: #{@user_3.created_at}")
+        end
+
+        within ".default-user-#{@user_4.id}" do
+          expect(page).to have_content("Joined: #{@user_4.created_at}")
+        end
+      end
+    end
+
+    it "I see an 'Upgrade to Merchant' button beside each user name"
   end
 end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -24,17 +24,24 @@ RSpec.describe "as an admin" do
       visit admin_users_path
 
       within ".all-default-users" do
-        expect(page).to have_content (@user_1.name)
-        expect(page).to have_content (@user_2.name)
-        expect(page).to have_content (@user_3.name)
-        expect(page).to have_content (@user_4.name)
+        expect(page).to have_content(@user_1.name)
+        expect(page).to have_content(@user_2.name)
+        expect(page).to have_content(@user_3.name)
+        expect(page).to have_content(@user_4.name)
       end
     end
 
-    # it "I see each user's name as a link to a show page for that user" do
-    #   admin/users/5
-    # end
-    #
+    it "I see each user's name as a link to a show page for that user" do
+      visit admin_users_path
+      
+      within ".all-default-users" do
+        expect(page).to have_link(@user_1.name)
+        expect(page).to have_link(@user_2.name)
+        expect(page).to have_link(@user_3.name)
+        expect(page).to have_link(@user_4.name)
+      end
+    end
+
     # it "I see the date each user registered beside their name" do
     #
     # end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -64,6 +64,26 @@ RSpec.describe "as an admin" do
       end
     end
 
-    it "I see an 'Upgrade to Merchant' button beside each user name"
+    it "I see an 'Upgrade to Merchant' button beside each user name" do
+      visit admin_users_path
+
+      within ".all-default-users" do
+        within ".default-user-#{@user_1.id}" do
+          expect(page).to have_button("Upgrade to Merchant")
+        end
+
+        within ".default-user-#{@user_2.id}" do
+          expect(page).to have_button("Upgrade to Merchant")
+        end
+
+        within ".default-user-#{@user_3.id}" do
+          expect(page).to have_button("Upgrade to Merchant")
+        end
+
+        within ".default-user-#{@user_4.id}" do
+          expect(page).to have_button("Upgrade to Merchant")
+        end
+      end
+    end
   end
 end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe "as an admin" do
+  describe "when I visit the users index page" do
+    before :each do
+      @admin_1 = User.create!(email: "admin_1@gmail.com", role: 2, name: "Admin 1", address: "Admin 1 Address", city: "Admin 1 City", state: "Admin 1 State", zip: "12345", password: "123456")
+      @admin_2 = User.create!(email: "admin_2@gmail.com", role: 2, name: "Admin 2", address: "Admin 2 Address", city: "Admin 2 City", state: "Admin 2 State", zip: "22345", password: "123456")
+      @merchant_1 = User.create!(email: "merchant_1@gmail.com", role: 1, name: "Merchant 1", address: "Merchant 1 Address", city: "Merchant 1 City", state: "Merchant 1 State", zip: "32345", password: "123456")
+      @merchant_2 = User.create!(email: "merchant_2@gmail.com", role: 1, name: "Merchant 2", address: "Merchant 2 Address", city: "Merchant 2 City", state: "Merchant 2 State", zip: "42345", password: "123456")
+      @user_1 = User.create!(email: "user_1@gmail.com", role: 0, name: "User 1", address: "User 1 Address", city: "User 1 City", state: "User 1 State", zip: "52345", password: "123456")
+      @user_2 = User.create!(email: "user_2@gmail.com", role: 0, name: "User 2", address: "User 2 Address", city: "User 2 City", state: "User 2 State", zip: "62345", password: "123456")
+      @user_3 = User.create!(email: "user_3@gmail.com", role: 0, name: "User 3", address: "User 3 Address", city: "User 3 City", state: "User 3 State", zip: "72345", password: "123456")
+      @user_4 = User.create!(email: "user_4@gmail.com", role: 0, name: "User 4", address: "User 4 Address", city: "User 4 City", state: "User 4 State", zip: "82345", password: "123456")
+
+      visit root_path
+
+      click_on "LogIn"
+      fill_in "email", with: @admin_1.email
+      fill_in "password", with: @admin_1.password
+      click_on "Log In"
+    end
+
+    it "it displays all users in the system who are not merchants or admins" do
+      visit admin_users_path
+
+      within ".all-default-users" do
+        expect(page).to have_content (@user_1.name)
+        expect(page).to have_content (@user_2.name)
+        expect(page).to have_content (@user_3.name)
+        expect(page).to have_content (@user_4.name)
+      end
+    end
+
+    # it "I see each user's name as a link to a show page for that user" do
+    #   admin/users/5
+    # end
+    #
+    # it "I see the date each user registered beside their name" do
+    #
+    # end
+    #
+    # it "I see an 'Upgrade to Merchant' button beside each user name" do
+    #
+    # end
+  end
+end

--- a/spec/features/welcome/index_spec.rb
+++ b/spec/features/welcome/index_spec.rb
@@ -173,6 +173,18 @@ RSpec.describe "when I visit the welcome page" do
         expect(current_path).to eq(admin_dashboard_path)
       end
     end
+
+    it "the page displays a link to a users index" do
+      visit root_path
+
+      within ".navbar" do
+        expect(page).to have_link("Users")
+
+        click_link("Users")
+
+        expect(current_path).to eq(admin_users_path)
+      end
+    end
   end
 end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,6 +54,10 @@ RSpec.describe User, type: :model do
       @order_item_9 = @order_4.order_items.create!(item_id: @item_10.id, quantity: 100, price: 100.00, fulfilled: true, created_at: Time.zone.local(2018, 11, 24, 01, 04, 44), updated_at: Time.zone.local(2018, 11, 25, 01, 04, 44))
     end
 
+    it ".find_default_users" do
+      expect(User.find_default_users).to eq ([@user_2, @user_5, @user_7, @user_8, @user_9, @user_10])
+    end
+
     it ".find_merchants" do
       expect(@users.find_merchants).to eq([@user_1, @user_3, @user_4, @user_6])
     end


### PR DESCRIPTION
This PR adds an Admin Users index page.

- Add admin_users_path, admin_user_path and admin_merchant_path to routes
- Add Users link to nav bar that will only display for an admin
- Add Admin::UsersController, index action and view
- Add current_admin? helper method to ApplicationController
- Add require_admin before_action to Admin::BaseController
- Add User find_default_users class method with spec
- Add Admin User index view components with feature specs