### PR TITLE
Admin Users Show

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,0 +1,5 @@
+class Admin::OrdersController < Admin::BaseController
+  def index
+
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,4 +2,8 @@ class Admin::UsersController < Admin::BaseController
   def index
     @default_users = User.find_default_users
   end
+
+  def show
+    @user = User.find(params[:id])
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,7 @@ class User < ApplicationRecord
   validates :password, presence: true, length: (6..51)
 
   def self.find_default_users
-    where(role: "default")
+    where(role: "default").order(name: :asc)
   end
 
   def self.find_merchants

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -7,4 +7,6 @@
   <p><%= @user.city %></p>
   <p><%= @user.state %></p>
   <p><%= @user.zip %></p>
+
+  <%= link_to "View Orders", admin_user_orders_path(@user) %>
 </section>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -8,5 +8,5 @@
   <p><%= @user.state %></p>
   <p><%= @user.zip %></p>
 
-  <%= link_to "View Orders", admin_user_orders_path(@user) %>
+  <%= link_to "View Orders", admin_user_orders_path(@user) if !@user.orders.empty? %>
 </section>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,10 @@
+<h2><%= @user.name %></h2>
+
+<section class="user-profile-<%= @user.id %>">
+  <p><%= @user.name %></p>
+  <p><%= @user.email %></p>
+  <p><%= @user.address %></p>
+  <p><%= @user.city %></p>
+  <p><%= @user.state %></p>
+  <p><%= @user.zip %></p>
+</section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,8 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get '/dashboard', to: 'dashboard#index'
-    get '/dashboard/:id', to: 'merchants#show', as: :merchant_path
+    get '/dashboard/:id', to: 'merchants#show', as: :merchant
+    get '/users/:user_id/orders', to: 'orders#index', as: :user_orders
 
     resources :users, only: [:index, :show]
   end

--- a/spec/features/admin/users/index_spec.rb
+++ b/spec/features/admin/users/index_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe "as an admin" do
         expect(page).to have_content(@user_3.name)
         expect(page).to have_content(@user_4.name)
       end
+
+      within ".all-default-users" do
+        expect(page).to_not have_content(@admin_2.name)
+        expect(page).to_not have_content(@merchant_1.name)
+        expect(page).to_not have_content(@merchant_2.name)
+      end
     end
 
     it "I see each user's name as a link to a show page for that user" do

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -4,7 +4,12 @@ RSpec.describe "as an admin" do
   describe "when I visit a user's show page" do
     before :each do
       @admin = User.create!(email: "admin@gmail.com", role: 2, name: "Admin", address: "Admin Address", city: "Admin City", state: "Admin State", zip: "12345", password: "123456")
-      @user = User.create!(email: "user@gmail.com", role: 0, name: "User", address: "User Address", city: "User City", state: "User State", zip: "52345", password: "123456", created_at: 4.days.ago)
+      @merchant = User.create!(email: "merchant@gmail.com", role: 1, name: "Merchant", address: "Merchant Address", city: "Merchant City", state: "Merchant State", zip: "22345", password: "123456")
+      @user = User.create!(email: "user@gmail.com", role: 0, name: "User", address: "User Address", city: "User City", state: "User State", zip: "52345", password: "123456")
+
+      @item = @user.items.create!(name: "Item", active: true, price: 1.00, description: "Item Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 10)
+      @order = @user.orders.create!(status: 3)
+      @order_item = @order.order_items.create!(item_id: @item.id, quantity: 1, price: 1.00, fulfilled: true)
 
       visit root_path
 
@@ -35,7 +40,9 @@ RSpec.describe "as an admin" do
       end
     end
 
-    it "I see a link to view the user's orders" do
+    it "I see a link to view the user's orders, unless the user has no orders" do
+      no_order_user = User.create!(email: "no_order_user@gmail.com", role: 2, name: "No Order User", address: "No Order User Address", city: "No Order User City", state: "No Order User State", zip: "12345", password: "123456")
+
       visit admin_user_path(@user)
 
       within ".user-profile-#{@user.id}" do
@@ -44,6 +51,12 @@ RSpec.describe "as an admin" do
         click_link "View Orders"
 
         expect(current_path).to eq(admin_user_orders_path(@user))
+      end
+
+      visit admin_user_path(no_order_user)
+
+      within ".user-profile-#{no_order_user.id}" do
+        expect(page).to_not have_link("View Orders")
       end
     end
   end

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -34,5 +34,17 @@ RSpec.describe "as an admin" do
         expect(page).to_not have_link("Edit My Profile")
       end
     end
+
+    it "I see a link to view the user's orders" do
+      visit admin_user_path(@user)
+
+      within ".user-profile-#{@user.id}" do
+        expect(page).to have_link("View Orders")
+
+        click_link "View Orders"
+
+        expect(current_path).to eq(admin_user)
+      end
+    end
   end
 end

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -17,14 +17,22 @@ RSpec.describe "as an admin" do
     it "I see all the same information that user would see" do
       visit admin_user_path(@user)
 
-      expect(page).to have_content(@user.name)
-      expect(page).to have_content(@user.email)
-      expect(page).to have_content(@user.address)
-      expect(page).to have_content(@user.city)
-      expect(page).to have_content(@user.state)
-      expect(page).to have_content(@user.zip)
+      within ".user-profile-#{@user.id}" do
+        expect(page).to have_content(@user.name)
+        expect(page).to have_content(@user.email)
+        expect(page).to have_content(@user.address)
+        expect(page).to have_content(@user.city)
+        expect(page).to have_content(@user.state)
+        expect(page).to have_content(@user.zip)
+      end
     end
 
-    it "I do not see a link to edit the user's profile"
+    it "I do not see a link to edit the user's profile" do
+      visit admin_user_path(@user)
+
+      within ".user-profile-#{@user.id}" do
+        expect(page).to_not have_link("Edit My Profile")
+      end
+    end
   end
 end

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe "as an admin" do
+  describe "when I visit a user's show page" do
+    before :each do
+      @admin = User.create!(email: "admin@gmail.com", role: 2, name: "Admin", address: "Admin Address", city: "Admin City", state: "Admin State", zip: "12345", password: "123456")
+      @user = User.create!(email: "user@gmail.com", role: 0, name: "User", address: "User Address", city: "User City", state: "User State", zip: "52345", password: "123456", created_at: 4.days.ago)
+
+      visit root_path
+
+      click_on "LogIn"
+      fill_in "email", with: @admin.email
+      fill_in "password", with: @admin.password
+      click_on "Log In"
+    end
+
+    it "I see all the same information that user would see" do
+      visit admin_user_path(@user)
+
+      expect(page).to have_content(@user.name)
+      expect(page).to have_content(@user.email)
+      expect(page).to have_content(@user.address)
+      expect(page).to have_content(@user.city)
+      expect(page).to have_content(@user.state)
+      expect(page).to have_content(@user.zip)
+    end
+
+    it "I do not see a link to edit the user's profile"
+  end
+end

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe "as an admin" do
 
         click_link "View Orders"
 
-        expect(current_path).to eq(admin_user)
+        expect(current_path).to eq(admin_user_orders_path(@user))
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe User, type: :model do
     end
 
     it ".find_default_users" do
-      expect(User.find_default_users).to eq ([@user_2, @user_5, @user_7, @user_8, @user_9, @user_10])
+      expect(User.find_default_users).to eq([@user_2, @user_5, @user_7, @user_8, @user_9, @user_10])
     end
 
     it ".find_merchants" do


### PR DESCRIPTION
This PR adds admin access to a User profile page.

- Add Admin::OrdersController with index action and view
- Add show action to Admin::UsersController with view
- Fixed find_default_users method to include an order clause, to avoid intermittent test failure
- Add Admin User show view
- Add Admin Order index view