### PR TITLE
User cancels order

### DIFF
--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -5,6 +5,11 @@ class Profile::OrdersController < ApplicationController
   end
 
   def show
+  end
+
+  def destroy
     @order = Order.find(params[:id])
+    @order.cancel_items
+
   end
 end

--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -12,7 +12,6 @@ class Profile::OrdersController < ApplicationController
     @order = Order.find(params[:id])
     @order.update(status: 3)
     @order.cancel_items
-    require "pry"; binding.pry
     flash[:message] = "Order #{@order.id} cancelled."
     redirect_to(profile_path)
 

--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -5,11 +5,14 @@ class Profile::OrdersController < ApplicationController
   end
 
   def show
+    @order = Order.find(params[:id])
   end
 
   def destroy
     @order = Order.find(params[:id])
+    @order.update(status: 3)
     @order.cancel_items
+    redirect_to(profile_path)
 
   end
 end

--- a/app/controllers/profile/orders_controller.rb
+++ b/app/controllers/profile/orders_controller.rb
@@ -12,6 +12,8 @@ class Profile::OrdersController < ApplicationController
     @order = Order.find(params[:id])
     @order.update(status: 3)
     @order.cancel_items
+    require "pry"; binding.pry
+    flash[:message] = "Order #{@order.id} cancelled."
     redirect_to(profile_path)
 
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -14,13 +14,16 @@ class Order < ApplicationRecord
           .limit(3)
 
   end
-    
+
   def total_item_count
     items.sum(:quantity)
   end
 
   def total_price
     order_items.sum(:price)
+  end
 
+  def cancel_items
+    items.each{|item| item.update(fulfilled: :false)}
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -24,6 +24,6 @@ class Order < ApplicationRecord
   end
 
   def cancel_items
-    items.each{|item| item.update(fulfilled: :false)}
+    order_items.each{|order_item| order_item.update(fulfilled: false)}
   end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,13 +12,9 @@ class Order < ApplicationRecord
           .group('orders.id')
           .order('order_item_quantity desc')
           .limit(3)
-<<<<<<< HEAD
-        end
 
-=======
   end
     
->>>>>>> 66fe9b12e4d4658ca92be887ca1c5d842b50d30b
   def total_item_count
     items.sum(:quantity)
   end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -12,6 +12,7 @@ class Order < ApplicationRecord
           .group('orders.id')
           .order('order_item_quantity desc')
           .limit(3)
+        end
 
   def total_item_count
     items.sum(:quantity)

--- a/app/views/profile/orders/index.html.erb
+++ b/app/views/profile/orders/index.html.erb
@@ -1,5 +1,6 @@
 <%current_user.orders.each do |order| %>
 <section id="Order-<%= order.id %>">
+  <p><%= "Order Cancelled" if order.cancelled? %></p>
   <%= link_to("Order #{order.id}", profile_order_path(order)) %>
   <p>Placed: <%= order.created_at.to_date %></p>
   <p>Updated: <%= order.updated_at.to_date %></p>

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -1,5 +1,5 @@
 <h1>Order: <%= @order.id %></h1>
-
+<%= link_to "Cancel Order", profile_order_path(@order), method: :delete if @order.pending? %>
 <p>Placed: <%= @order.created_at.to_date %></p>
 <p>Updated: <%= @order.updated_at.to_date %></p>
 <p>Status: <%= @order.status %></p>

--- a/app/views/profile/orders/show.html.erb
+++ b/app/views/profile/orders/show.html.erb
@@ -1,0 +1,17 @@
+<h1>Order: <%= @order.id %></h1>
+
+<p>Placed: <%= @order.created_at.to_date %></p>
+<p>Updated: <%= @order.updated_at.to_date %></p>
+<p>Status: <%= @order.status %></p>
+<p>Number of Items: <%= @order.total_item_count %></p>
+<p>Total Cost: <%= @order.total_price %></p>
+<br><br>
+<% @order.items.each do |item| %>
+<section id="item-<%= item.id %>">
+  <p><%= item.name %></p>
+<p>Price Per Item: <%= number_to_currency(item.price) %></p>
+<p><%= item.description %></p>
+<p>Subtotal: <%= number_to_currency(item.find_order_item(@order.id).price) %></p>
+<img src="<%=item.image%>">
+</section>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
   get '/profile', to: "users#show"
   get '/profile/edit', to: "users#edit"
   namespace :profile do
-    resources :orders, only: [:index, :show]
+    resources :orders, only: [:index, :show, :destroy]
   end
   put '/users', to: "users#update"
 
@@ -32,4 +32,5 @@ Rails.application.routes.draw do
   namespace :admin do
     get '/dashboard', to: 'dashboard#index'
   end
+
 end

--- a/spec/features/users/orders/show_spec.rb
+++ b/spec/features/users/orders/show_spec.rb
@@ -71,12 +71,12 @@ describe "as a registered user" do
     it "lets me cancel an order" do
       visit profile_order_path(@order_1)
       click_link("Cancel Order")
-      expect(@order_item_1.fulfilled).to eq(false)
-      expect(@order_item_4.fulfilled).to eq(false)
-      expect(@order_1.status).to eq("cancelled")
+      expect(OrderItem.find(@order_item_1.id).fulfilled).to eq(false)
+      expect(OrderItem.find(@order_item_4.id).fulfilled).to eq(false)
+      expect(Order.find(@order_1.id).status).to eq("cancelled")
       #return item quantities to merchant page
       expect(current_path).to eq(profile_path)
-      expect(page).to have_content("Order #{@order_1} cancelled.")
+      expect(page).to have_content("Order #{@order_1.id} cancelled.")
 
       within "#Order-#{@order_1.id}" do
         expect(page).to have_content("Status: cancelled")

--- a/spec/features/users/orders/show_spec.rb
+++ b/spec/features/users/orders/show_spec.rb
@@ -77,10 +77,13 @@ describe "as a registered user" do
       #return item quantities to merchant page
       expect(current_path).to eq(profile_path)
       expect(page).to have_content("Order #{@order_1.id} cancelled.")
-
+      visit profile_orders_path
+      save_and_open_page
       within "#Order-#{@order_1.id}" do
         expect(page).to have_content("Status: cancelled")
       end
+      visit profile_order_path(@order_1)
+      expect(page).to have_content("Status: cancelled")
     end
 
     it "only lets me cancel pending orders" do

--- a/spec/features/users/orders/show_spec.rb
+++ b/spec/features/users/orders/show_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+include ActionView::Helpers::NumberHelper
+
+describe "as a registered user" do
+  describe "when I visit an order show page" do
+    before :each do
+      @user_1 = User.create!(email: "user_1@gmail.com", role: 2, name: "User 1", address: "User 1 Address", city: "User 1 City", state: "User 1 State", zip: "12345", password: "123456")
+      @user_2 = User.create!(email: "user_2@gmail.com", role: 2, name: "User 2", address: "User 2 Address", city: "User 2 City", state: "User 2 State", zip: "22345", password: "123456")
+
+      @user_8 = User.create!(email: "user_8@gmail.com", role: 0, name: "User 8", address: "User 8 Address", city: "User 8 City", state: "User 8 State", zip: "82345", password: "123456")
+
+      @item_1 = @user_1.items.create!(name: "Item 1", active: true, price: 1.00, description: "Item 1 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 10)
+      @item_2 = @user_2.items.create!(name: "Item 2", active: true, price: 2.00, description: "Item 2 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 15)
+
+      @order_1 = @user_8.orders.create!(status: 3)
+      @order_2 = @user_8.orders.create!(status: 2)
+
+      @order_item_1 = @order_1.order_items.create!(item_id: @item_1.id, quantity: 1, price: 1.00, fulfilled: true)
+      @order_item_2 = @order_2.order_items.create!(item_id: @item_1.id, quantity: 1, price: 1.00, fulfilled: true)
+      @order_item_3 = @order_2.order_items.create!(item_id: @item_2.id, quantity: 2, price: 4.00, fulfilled: true)
+
+      visit root_path
+
+      click_on "LogIn"
+
+      expect(current_path).to eq(login_path)
+      fill_in "email", with: @user_8.email
+      fill_in "password", with: @user_8.password
+
+      click_on "Log In"
+    end
+
+    it "has an item show page" do
+      visit profile_order_path(@order_2)
+      save_and_open_page
+      expect(page).to have_content("Order: #{@order_2.id}")
+      expect(page).to have_content("Placed: #{@order_2.created_at.to_date}")
+      expect(page).to have_content("Updated: #{@order_2.updated_at.to_date}")
+      expect(page).to have_content("Status: #{@order_2.status}")
+      expect(page).to have_content("Number of Items: #{@order_2.total_item_count}")
+      expect(page).to have_content("Total Cost: #{@order_2.total_price}")
+
+      within "#item-#{@item_1.id}" do
+        expect(page).to have_content(@item_1.name)
+        expect(page).to have_content("Price Per Item: #{number_to_currency(@item_1.price)}")
+        expect(page).to have_content(@order_item_1.quantity)
+        expect(page).to have_content("Subtotal: #{number_to_currency(@order_item_1.price)}")
+        expect(page).to have_content(@item_1.description)
+        find "img[src='#{@item_1.image}']"
+      end
+      within "#item-#{@item_2.id}" do
+        expect(page).to have_content(@item_2.name)
+        expect(page).to have_content("Price Per Item: #{number_to_currency(@item_2.price)}")
+        expect(page).to have_content(@order_item_3.quantity)
+        expect(page).to have_content("Subtotal: #{number_to_currency(@order_item_3.price)}")
+        expect(page).to have_content(@item_2.description)
+        find "img[src='#{@item_2.image}']"
+      end
+    end
+  end
+end

--- a/spec/features/users/orders/show_spec.rb
+++ b/spec/features/users/orders/show_spec.rb
@@ -33,7 +33,6 @@ describe "as a registered user" do
 
     it "has an item show page" do
       visit profile_order_path(@order_2)
-      save_and_open_page
       expect(page).to have_content("Order: #{@order_2.id}")
       expect(page).to have_content("Placed: #{@order_2.created_at.to_date}")
       expect(page).to have_content("Updated: #{@order_2.updated_at.to_date}")
@@ -59,6 +58,16 @@ describe "as a registered user" do
       end
     end
 
+#
+# If the order is still "pending", I see a button or link to cancel the order
+# When I click the cancel button for an order, the following happens:
+# - Each row in the "order items" table is given a status of "unfulfilled"
+# - The order itself is given a status of "cancelled"
+# - Any item quantities in the order that were previously fulfilled have their quantities returned to their respective merchant's inventory for that item.
+# - I am returned to my profile page
+# - I see a flash message telling me the order is now cancelled
+# - And I see that this order now has an updated status of "cancelled"
+
     it "lets me cancel an order" do
       visit profile_order_path(@order_1)
       click_link("Cancel Order")
@@ -70,8 +79,13 @@ describe "as a registered user" do
       expect(page).to have_content("Order #{@order_1} cancelled.")
 
       within "#Order-#{@order_1.id}" do
-        expect(page).to have_content("Status: "cancelled")
+        expect(page).to have_content("Status: cancelled")
       end
+    end
+
+    it "only lets me cancel pending orders" do
+      visit profile_order_path(@order_2)
+      expect(page).to_not have_link("Cancel Order")
 
     end
   end

--- a/spec/features/users/orders/show_spec.rb
+++ b/spec/features/users/orders/show_spec.rb
@@ -71,8 +71,8 @@ describe "as a registered user" do
     it "lets me cancel an order" do
       visit profile_order_path(@order_1)
       click_link("Cancel Order")
-      expect(@order_item_1.status).to eq("unfulfilled")
-      expect(@order_item_4.status).to eq("unfilfilled")
+      expect(@order_item_1.fulfilled).to eq(false)
+      expect(@order_item_4.fulfilled).to eq(false)
       expect(@order_1.status).to eq("cancelled")
       #return item quantities to merchant page
       expect(current_path).to eq(profile_path)

--- a/spec/features/users/orders/show_spec.rb
+++ b/spec/features/users/orders/show_spec.rb
@@ -12,10 +12,11 @@ describe "as a registered user" do
       @item_1 = @user_1.items.create!(name: "Item 1", active: true, price: 1.00, description: "Item 1 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 10)
       @item_2 = @user_2.items.create!(name: "Item 2", active: true, price: 2.00, description: "Item 2 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 15)
 
-      @order_1 = @user_8.orders.create!(status: 3)
+      @order_1 = @user_8.orders.create!(status: 0)
       @order_2 = @user_8.orders.create!(status: 2)
 
       @order_item_1 = @order_1.order_items.create!(item_id: @item_1.id, quantity: 1, price: 1.00, fulfilled: true)
+      @order_item_4 = @order_1.order_items.create!(item_id: @item_2.id, quantity: 1, price: 1.00, fulfilled: true)
       @order_item_2 = @order_2.order_items.create!(item_id: @item_1.id, quantity: 1, price: 1.00, fulfilled: true)
       @order_item_3 = @order_2.order_items.create!(item_id: @item_2.id, quantity: 2, price: 4.00, fulfilled: true)
 
@@ -56,6 +57,22 @@ describe "as a registered user" do
         expect(page).to have_content(@item_2.description)
         find "img[src='#{@item_2.image}']"
       end
+    end
+
+    it "lets me cancel an order" do
+      visit profile_order_path(@order_1)
+      click_link("Cancel Order")
+      expect(@order_item_1.status).to eq("unfulfilled")
+      expect(@order_item_4.status).to eq("unfilfilled")
+      expect(@order_1.status).to eq("cancelled")
+      #return item quantities to merchant page
+      expect(current_path).to eq(profile_path)
+      expect(page).to have_content("Order #{@order_1} cancelled.")
+
+      within "#Order-#{@order_1.id}" do
+        expect(page).to have_content("Status: "cancelled")
+      end
+
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -55,6 +55,8 @@ RSpec.describe Order, type: :model do
 
     it '.top_three_order_item_quantity' do
       expect(@orders.top_three_order_item_quantity).to eq([@order_4, @order_1, @order_2])
+    end
+  end
 
   describe "instance methods" do
       before :each do
@@ -85,7 +87,6 @@ RSpec.describe Order, type: :model do
     it "#total_price" do
       expect(@order_1.total_price).to eq(2.00)
       expect(@order_2.total_price).to eq(9.00)
-
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -88,5 +88,12 @@ RSpec.describe Order, type: :model do
       expect(@order_1.total_price).to eq(2.00)
       expect(@order_2.total_price).to eq(9.00)
     end
+
+    it "#cancel_items" do
+      @order_1.cancel_items
+      expect(@order_item_4.fulfilled).to eq(false)
+      expect(@order_item_1.fulfilled).to eq(false)
+
+    end
   end
 end


### PR DESCRIPTION
This PR 
-Adds spec for user cancels order which goes in and checks DB to see order is cancelled and items are unfilfilled
-Adds Destroy  profile::orders controller action which does this work ^^ and corresponding route
-Adds test to check order index and show that the order displays as cancelled.

DOES NOT RETURN MERCHANTS THEIR INVENTORY
-opening separate tag

Those really odd commits are from when I was trying to pull down someone elses on master to test.