### PR TITLE
Admin User Merchant Redirect

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,6 +5,8 @@ class Admin::UsersController < Admin::BaseController
 
   def show
     @user = User.find(params[:id])
+
+    redirect_to admin_merchant_path(@user) if @user.merchant?
   end
 
   def upgrade

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe "when I visit a user's show page" do
       end
     end
 
+    describe "and that user is a merchant" do
+      it "I'm redirected to their merchant dashboard" do
+        visit admin_user_path(@merchant)
+
+        expect(current_path).to eq(admin_merchant_path(@merchant))
+      end
+    end
+
     context "as a visitor" do
       it "I recieve a 404 error" do
         click_link "Logout"


### PR DESCRIPTION
This PR adds a redirect to the Admin UsersController show action.

- If the user has been converted to a Merchant, the Admin will be redirected from the User show page to the merchant dashboard.