### PR TITLE
Admin Merchant Downgrade

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -23,7 +23,8 @@ class Admin::MerchantsController < Admin::BaseController
 
   def downgrade
     merchant = User.find(params[:merchant_id])
-    merchant.update(role: 0)
+    merchant.deactivate_all_items
+    merchant.downgrade_to_user
 
     flash[:notice] = "#{merchant.name} has been downgraded to a User."
 

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -20,4 +20,13 @@ class Admin::MerchantsController < Admin::BaseController
     end
     redirect_to merchants_path
   end
+
+  def downgrade
+    merchant = User.find(params[:merchant_id])
+    merchant.update(role: 0)
+
+    flash[:notice] = "#{merchant.name} has been downgraded to a User."
+
+    redirect_to admin_user_path(merchant)
+  end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -9,7 +9,7 @@ class Admin::UsersController < Admin::BaseController
 
   def upgrade
     user = User.find(params[:user_id])
-    user.update(role: 1)
+    user.upgrade_to_merchant
 
     flash[:notice] = "#{user.name} has been upgraded to a Merchant."
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,6 +62,10 @@ class User < ApplicationRecord
     .limit(5)
   end
 
+  def deactivate_all_items
+    items.update(active: false)
+  end
+
   # - total quantity of items I've sold, and as a percentage against my sold units plus remaining inventory (eg, if I have sold 1,000 things and still have 9,000 things in inventory, the message would say something like "Sold 1,000 items, which is 10% of your total inventory")
   # def total_quantity_items_sold
   #   # items.sum('order_items.quantity')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -70,6 +70,10 @@ class User < ApplicationRecord
     update(role: 0)
   end
 
+  def upgrade_to_merchant
+    update(role: 1)
+  end
+
   # - total quantity of items I've sold, and as a percentage against my sold units plus remaining inventory (eg, if I have sold 1,000 things and still have 9,000 things in inventory, the message would say something like "Sold 1,000 items, which is 10% of your total inventory")
   # def total_quantity_items_sold
   #   # items.sum('order_items.quantity')

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -66,6 +66,10 @@ class User < ApplicationRecord
     items.update(active: false)
   end
 
+  def downgrade_to_user
+    update(role: 0)
+  end
+
   # - total quantity of items I've sold, and as a percentage against my sold units plus remaining inventory (eg, if I have sold 1,000 things and still have 9,000 things in inventory, the message would say something like "Sold 1,000 items, which is 10% of your total inventory")
   # def total_quantity_items_sold
   #   # items.sum('order_items.quantity')

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -1,7 +1,11 @@
-
 <br>
 Merchant Info:<br>
 <br>
+
+<% if current_user && current_user.admin? %>
+  <%= button_to "Downgrade to User", "/admin/merchants/downgrade/#{@merchant.id}", method: :patch %>
+<% end %>
+
 <% if @merchant.merchant?; %><h1>Logged in as: <%= current_user.email %></h1><% end %>
 <%= @merchant.name %>
 (<%= @merchant.email %>)<br>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -40,6 +40,7 @@ Rails.application.routes.draw do
     get '/dashboard', to: 'dashboard#index'
     get '/users/:user_id/orders', to: 'orders#index', as: :user_orders
     patch '/users/upgrade/:user_id', to: 'users#upgrade', as: :user_upgrade
+    patch '/merchants/downgrade/:merchant_id', to: 'merchants#downgrade', as: :merchant_downgrade
 
     resources :merchants, only: [:show, :update]
     resources :users, only: [:index, :show]

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -45,22 +45,22 @@ RSpec.describe "when I visit a merchant's show page" do
       expect(page).to have_button("Downgrade to User")
     end
 
-    # describe "and click the 'Downgrade to User' button" do
-    #   it "I am redirected to that merchant's user profile" do
-    #     visit admin_user_path(@merchant)
-    #
-    #     click_button "Downgrade to User"
-    #
-    #     expect(current_path).to eq(admin_user_path(@merchant))
-    #   end
-    #
-    #   it "I see a flash message indicated that the user has been upgraded" do
-    #     visit admin_merchant_path(@merchant)
-    #
-    #     click_button "Downgrade to User"
-    #
-    #     expect(page).to have_content("#{@merchant.name} has been downgraded to a User.")
-    #   end
+    describe "and click the 'Downgrade to User' button" do
+      it "I am redirected to that merchant's user profile" do
+        visit admin_merchant_path(@merchant)
+
+        click_button "Downgrade to User"
+
+        expect(current_path).to eq(admin_user_path(@merchant))
+      end
+
+      # it "I see a flash message indicated that the user has been upgraded" do
+      #   visit admin_merchant_path(@merchant)
+      #
+      #   click_button "Downgrade to User"
+      #
+      #   expect(page).to have_content("#{@merchant.name} has been downgraded to a User.")
+      # end
     #
     #   it "the user becomes a merchant" do
     #     visit admin_merchant_path(@merchant)
@@ -118,6 +118,6 @@ RSpec.describe "when I visit a merchant's show page" do
     #     expect(page.status_code).to eq(404)
     #     expect(page).to have_content("The page you were looking for doesn't exist.")
     #   end
-    # end
+    end
   end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -1,0 +1,123 @@
+require 'rails_helper'
+
+RSpec.describe "when I visit a merchant's show page" do
+  describe "as an admin" do
+    before :each do
+      @admin = User.create!(email: "admin@gmail.com", role: 2, active: true, name: "Admin", address: "Admin Address", city: "Admin City", state: "Admin State", zip: "12345", password: "123456")
+      @merchant = User.create!(email: "merchant@gmail.com", role: 1, active: true, name: "Merchant", address: "Merchant Address", city: "Merchant City", state: "Merchant State", zip: "22345", password: "123456")
+      @user = User.create!(email: "user@gmail.com", role: 0, active: true, name: "User", address: "User Address", city: "User City", state: "User State", zip: "52345", password: "123456")
+
+      @item = @merchant.items.create!(name: "Item", active: true, price: 1.00, description: "Item Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 10)
+      @order = @user.orders.create!(status: 3)
+      @order_item = @order.order_items.create!(item_id: @item.id, quantity: 1, price: 1.00, fulfilled: true)
+
+      visit root_path
+
+      click_on "LogIn"
+      fill_in "email", with: @admin.email
+      fill_in "password", with: @admin.password
+      click_on "Log In"
+    end
+
+    it "I see all the same information that merchant would see" do
+      visit admin_merchant_path(@merchant)
+
+      expect(page).to have_content(@merchant.name)
+      expect(page).to have_content(@merchant.email)
+      expect(page).to have_content(@merchant.address)
+      expect(page).to have_content(@merchant.city)
+      expect(page).to have_content(@merchant.state)
+      expect(page).to have_content(@merchant.zip)
+
+      within "#item-#{@item.id}" do
+        expect(page).to have_content(@item.name)
+        expect(page).to have_content(@item.inventory)
+        expect(page).to have_content("Edit")
+        expect(page).to have_content("Disable")
+        expect(page).to_not have_content("Enable")
+        expect(page).to have_content("Delete")
+      end
+    end
+
+    it "the page displays a button to downgrade the merchant's account to a user account" do
+      visit admin_merchant_path(@merchant)
+
+      expect(page).to have_button("Downgrade to User")
+    end
+
+    # describe "and click the 'Downgrade to User' button" do
+    #   it "I am redirected to that merchant's user profile" do
+    #     visit admin_user_path(@merchant)
+    #
+    #     click_button "Downgrade to User"
+    #
+    #     expect(current_path).to eq(admin_user_path(@merchant))
+    #   end
+    #
+    #   it "I see a flash message indicated that the user has been upgraded" do
+    #     visit admin_merchant_path(@merchant)
+    #
+    #     click_button "Downgrade to User"
+    #
+    #     expect(page).to have_content("#{@merchant.name} has been downgraded to a User.")
+    #   end
+    #
+    #   it "the user becomes a merchant" do
+    #     visit admin_merchant_path(@merchant)
+    #
+    #     click_button "Downgrade to a User"
+    #
+    #     @merchant.reload
+    #
+    #     expect(@merchant.role).to eq("user")
+    #   end
+    # end
+    #
+    # context "as a visitor" do
+    #   it "I recieve a 404 error" do
+    #     click_link "Logout"
+    #
+    #     visit admin_merchant_path(@merchant)
+    #
+    #     expect(page.status_code).to eq(404)
+    #     expect(page).to have_content("The page you were looking for doesn't exist.")
+    #   end
+    # end
+    #
+    # context "as a user" do
+    #   it "I recieve a 404 error" do
+    #     click_link "Logout"
+    #
+    #     visit root_path
+    #
+    #     click_on "LogIn"
+    #     fill_in "email", with: @user.email
+    #     fill_in "password", with: @user.password
+    #     click_on "Log In"
+    #
+    #     visit admin_merchant_path(@merchant)
+    #
+    #     expect(page.status_code).to eq(404)
+    #     expect(page).to have_content("The page you were looking for doesn't exist.")
+    #   end
+    # end
+    #
+    # context "as a merchant" do
+    #   it "I recieve a 404 error" do
+    #     click_link "Logout"
+    #
+    #     visit root_path
+    #
+    #     click_on "LogIn"
+    #     fill_in "email", with: @merchant.email
+    #     fill_in "password", with: @merchant.password
+    #     click_on "Log In"
+    #
+    #     visit admin_merchant_path(@merchant)
+    #
+    #     expect(page.status_code).to eq(404)
+    #     expect(page).to have_content("The page you were looking for doesn't exist.")
+    #   end
+    # end
+  end
+end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -108,6 +108,11 @@ RSpec.describe "when I visit a merchant's show page" do
 
         click_button "Downgrade to User"
 
+        @item_1.reload
+        @item_2.reload
+        @item_3.reload
+        @item_4.reload
+
         expect(@item_1.active).to eq(false)
         expect(@item_2.active).to eq(false)
         expect(@item_3.active).to eq(false)

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -71,53 +71,50 @@ RSpec.describe "when I visit a merchant's show page" do
 
         expect(@merchant.role).to eq("default")
       end
-    # end
-    #
-    # context "as a visitor" do
-    #   it "I recieve a 404 error" do
-    #     click_link "Logout"
-    #
-    #     visit admin_merchant_path(@merchant)
-    #
-    #     expect(page.status_code).to eq(404)
-    #     expect(page).to have_content("The page you were looking for doesn't exist.")
-    #   end
-    # end
-    #
-    # context "as a user" do
-    #   it "I recieve a 404 error" do
-    #     click_link "Logout"
-    #
-    #     visit root_path
-    #
-    #     click_on "LogIn"
-    #     fill_in "email", with: @user.email
-    #     fill_in "password", with: @user.password
-    #     click_on "Log In"
-    #
-    #     visit admin_merchant_path(@merchant)
-    #
-    #     expect(page.status_code).to eq(404)
-    #     expect(page).to have_content("The page you were looking for doesn't exist.")
-    #   end
-    # end
-    #
-    # context "as a merchant" do
-    #   it "I recieve a 404 error" do
-    #     click_link "Logout"
-    #
-    #     visit root_path
-    #
-    #     click_on "LogIn"
-    #     fill_in "email", with: @merchant.email
-    #     fill_in "password", with: @merchant.password
-    #     click_on "Log In"
-    #
-    #     visit admin_merchant_path(@merchant)
-    #
-    #     expect(page.status_code).to eq(404)
-    #     expect(page).to have_content("The page you were looking for doesn't exist.")
-    #   end
+    end
+
+    context "as a visitor" do
+      it "I do not see the 'Downgrade to User' button" do
+        click_link "Logout"
+
+        visit admin_merchant_path(@merchant)
+
+        expect(page).to_not have_content("Downgrade to User")
+      end
+    end
+
+    context "as a user" do
+      it "I do not see the 'Downgrade to User' button" do
+        click_link "Logout"
+
+        visit root_path
+
+        click_on "LogIn"
+        fill_in "email", with: @user.email
+        fill_in "password", with: @user.password
+        click_on "Log In"
+
+        visit admin_merchant_path(@merchant)
+
+        expect(page).to_not have_content("Downgrade to User")
+      end
+    end
+
+    context "as a merchant" do
+      it "I do not see the 'Downgrade to User' button" do
+        click_link "Logout"
+
+        visit root_path
+
+        click_on "LogIn"
+        fill_in "email", with: @merchant.email
+        fill_in "password", with: @merchant.password
+        click_on "Log In"
+
+        visit admin_merchant_path(@merchant)
+
+        expect(page).to_not have_content("Downgrade to User")
+      end
     end
   end
 end

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -54,13 +54,13 @@ RSpec.describe "when I visit a merchant's show page" do
         expect(current_path).to eq(admin_user_path(@merchant))
       end
 
-      # it "I see a flash message indicated that the user has been upgraded" do
-      #   visit admin_merchant_path(@merchant)
-      #
-      #   click_button "Downgrade to User"
-      #
-      #   expect(page).to have_content("#{@merchant.name} has been downgraded to a User.")
-      # end
+      it "I see a flash message indicated that the user has been upgraded" do
+        visit admin_merchant_path(@merchant)
+
+        click_button "Downgrade to User"
+
+        expect(page).to have_content("#{@merchant.name} has been downgraded to a User.")
+      end
     #
     #   it "the user becomes a merchant" do
     #     visit admin_merchant_path(@merchant)

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -61,16 +61,16 @@ RSpec.describe "when I visit a merchant's show page" do
 
         expect(page).to have_content("#{@merchant.name} has been downgraded to a User.")
       end
-    #
-    #   it "the user becomes a merchant" do
-    #     visit admin_merchant_path(@merchant)
-    #
-    #     click_button "Downgrade to a User"
-    #
-    #     @merchant.reload
-    #
-    #     expect(@merchant.role).to eq("user")
-    #   end
+
+      it "the user becomes a merchant" do
+        visit admin_merchant_path(@merchant)
+
+        click_button "Downgrade to User"
+
+        @merchant.reload
+
+        expect(@merchant.role).to eq("default")
+      end
     # end
     #
     # context "as a visitor" do

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -7,9 +7,13 @@ RSpec.describe "when I visit a merchant's show page" do
       @merchant = User.create!(email: "merchant@gmail.com", role: 1, active: true, name: "Merchant", address: "Merchant Address", city: "Merchant City", state: "Merchant State", zip: "22345", password: "123456")
       @user = User.create!(email: "user@gmail.com", role: 0, active: true, name: "User", address: "User Address", city: "User City", state: "User State", zip: "52345", password: "123456")
 
-      @item = @merchant.items.create!(name: "Item", active: true, price: 1.00, description: "Item Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 10)
+      @item_1 = @merchant.items.create!(name: "Item 1", active: true, price: 1.00, description: "Item 1 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 10)
+      @item_2 = @merchant.items.create!(name: "Item 2", active: true, price: 2.00, description: "Item 2 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 15)
+      @item_3 = @merchant.items.create!(name: "Item 3", active: true, price: 3.00, description: "Item 3 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 20)
+      @item_4 = @merchant.items.create!(name: "Item 4", active: true, price: 4.00, description: "Item 4 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 25)
+
       @order = @user.orders.create!(status: 3)
-      @order_item = @order.order_items.create!(item_id: @item.id, quantity: 1, price: 1.00, fulfilled: true)
+      @order_item = @order.order_items.create!(item_id: @item_1.id, quantity: 1, price: 1.00, fulfilled: true)
 
       visit root_path
 
@@ -29,9 +33,36 @@ RSpec.describe "when I visit a merchant's show page" do
       expect(page).to have_content(@merchant.state)
       expect(page).to have_content(@merchant.zip)
 
-      within "#item-#{@item.id}" do
-        expect(page).to have_content(@item.name)
-        expect(page).to have_content(@item.inventory)
+      within "#item-#{@item_1.id}" do
+        expect(page).to have_content(@item_1.name)
+        expect(page).to have_content(@item_1.inventory)
+        expect(page).to have_content("Edit")
+        expect(page).to have_content("Disable")
+        expect(page).to_not have_content("Enable")
+        expect(page).to have_content("Delete")
+      end
+
+      within "#item-#{@item_2.id}" do
+        expect(page).to have_content(@item_2.name)
+        expect(page).to have_content(@item_2.inventory)
+        expect(page).to have_content("Edit")
+        expect(page).to have_content("Disable")
+        expect(page).to_not have_content("Enable")
+        expect(page).to have_content("Delete")
+      end
+
+      within "#item-#{@item_3.id}" do
+        expect(page).to have_content(@item_3.name)
+        expect(page).to have_content(@item_3.inventory)
+        expect(page).to have_content("Edit")
+        expect(page).to have_content("Disable")
+        expect(page).to_not have_content("Enable")
+        expect(page).to have_content("Delete")
+      end
+
+      within "#item-#{@item_4.id}" do
+        expect(page).to have_content(@item_4.name)
+        expect(page).to have_content(@item_4.inventory)
         expect(page).to have_content("Edit")
         expect(page).to have_content("Disable")
         expect(page).to_not have_content("Enable")
@@ -70,6 +101,17 @@ RSpec.describe "when I visit a merchant's show page" do
         @merchant.reload
 
         expect(@merchant.role).to eq("default")
+      end
+
+      it "all of the merchant's items are disabled" do
+        visit admin_merchant_path(@merchant)
+
+        click_button "Downgrade to User"
+
+        expect(@item_1.active).to eq(false)
+        expect(@item_2.active).to eq(false)
+        expect(@item_3.active).to eq(false)
+        expect(@item_4.active).to eq(false)
       end
     end
 

--- a/spec/features/admin/users/show_spec.rb
+++ b/spec/features/admin/users/show_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe "when I visit a user's show page" do
       @merchant = User.create!(email: "merchant@gmail.com", role: 1, active: true, name: "Merchant", address: "Merchant Address", city: "Merchant City", state: "Merchant State", zip: "22345", password: "123456")
       @user = User.create!(email: "user@gmail.com", role: 0, active: true, name: "User", address: "User Address", city: "User City", state: "User State", zip: "52345", password: "123456")
 
-      @item = @user.items.create!(name: "Item", active: true, price: 1.00, description: "Item Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 10)
+      @item = @merchant.items.create!(name: "Item", active: true, price: 1.00, description: "Item Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 10)
       @order = @user.orders.create!(status: 3)
       @order_item = @order.order_items.create!(item_id: @item.id, quantity: 1, price: 1.00, fulfilled: true)
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -185,5 +185,16 @@ RSpec.describe User, type: :model do
       order_item_41 = create(:order_item, item: @item_1, order: order_10)
       expect(@merchant_2.pending_orders).to eq([@order_8, order_9, order_10])
     end
+
+    it "#deactivate_all_items" do
+      @merchant_1.deactivate_all_items
+
+      expect(@item_1.active).to eq(false)
+      expect(@item_2.active).to eq(false)
+      expect(@item_3.active).to eq(false)
+      expect(@item_4.active).to eq(false)
+      expect(@item_5.active).to eq(false)
+      expect(@item_6.active).to eq(false)
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -196,5 +196,11 @@ RSpec.describe User, type: :model do
       expect(@item_5.active).to eq(false)
       expect(@item_6.active).to eq(false)
     end
+
+    it "#downgrade_to_user" do
+      @merchant_1.downgrade_to_user
+
+      expect(@merchant_1.role).to eq("default")
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -202,5 +202,11 @@ RSpec.describe User, type: :model do
 
       expect(@merchant_1.role).to eq("default")
     end
+
+    it "#upgrade_to_merchant" do
+      @user_2.upgrade_to_merchant
+
+      expect(@user_2.role).to eq("merchant")
+    end
   end
 end


### PR DESCRIPTION
This PR adds Admin functionality to downgrade a Merchant to a User.

- Add downgrade/upgrade_to_user/merchant instance methods to User model with specs
- Add 'Downgrade to User' button to Admin Merchants show view
- Add MerchantsController downgrade action
- Add deactivate_all_items instance method to User model with spec