### PR TITLE
Admin Merchant User Redirect

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -5,7 +5,12 @@ class Admin::MerchantsController < Admin::BaseController
     @items = @merchant.items
     @merchant_orders = @merchant.pending_orders
     @top_five_items_sold = @merchant.top_five_sold
-    render file: "/app/views/merchants/show.html", status: 200
+
+    if @merchant.default?
+      redirect_to admin_user_path(@merchant)
+    else
+      render file: "/app/views/merchants/show.html", status: 200
+    end
   end
 
   def update

--- a/spec/features/admin/merchants/show_spec.rb
+++ b/spec/features/admin/merchants/show_spec.rb
@@ -118,6 +118,14 @@ RSpec.describe "when I visit a merchant's show page" do
         expect(@item_3.active).to eq(false)
         expect(@item_4.active).to eq(false)
       end
+
+      describe "and that merchant is a user" do
+        it "I'm redirected to that user's show page" do
+          visit admin_merchant_path(@user)
+
+          expect(current_path).to eq(admin_user_path(@user))
+        end
+      end
     end
 
     context "as a visitor" do


### PR DESCRIPTION
This PR adds a redirect for the Admin when clicking on a Merchant's show page.  If that Merchant has been downgraded to a User, the Admin will be taken to that User's show page instead.