### PR TITLE
Fix Deprecation Warning

### DIFF
--- a/spec/features/merchants/orders/show_spec.rb
+++ b/spec/features/merchants/orders/show_spec.rb
@@ -82,17 +82,16 @@ describe "as a merchant" do
 
     it "Says Insufficient inventory If I cant fulfill and order" do
       within "#item-#{@item_5.id}" do
-      page.should have_css('h2', :text => 'Insufficient Inventory')
+        expect(page).to have_css('h2', :text => 'Insufficient Inventory')
       end
+
       within "#item-#{@item_1.id}" do
-      page.should_not have_css('h2', :text => 'Insufficient Inventory')
+        expect(page).to_not have_css('h2', :text => 'Insufficient Inventory')
       end
+
       within "#item-#{@item_2.id}" do
-      page.should_not have_css('h2', :text => 'Insufficient Inventory')
+        expect(page).to_not have_css('h2', :text => 'Insufficient Inventory')
       end
-
     end
-    
   end
-
 end


### PR DESCRIPTION
This PR updates the Merchant Order show page spec syntax to remove deprecation warning when running RSpec.