### PR TITLE
Admin Ships Orders

### DIFF
--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -2,4 +2,13 @@ class Admin::OrdersController < Admin::BaseController
   def index
 
   end
+
+  def ship
+    order = Order.find(params[:order_id])
+    order.ship
+
+    flash[:notice] = "Order #{order.id} shipped!"
+
+    redirect_to admin_dashboard_path
+  end
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -22,6 +22,9 @@ class Order < ApplicationRecord
 
   end
 
+  def ship
+    update(status: 2)
+  end
 
   def user_name
     user.name

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -4,6 +4,9 @@
   <% @orders.each do |order| %>
     <div class="order-<%= order.id %>">
       <p>Order <%= order.id %>: placed at <%= order.created_at %> by <%= link_to order.user_name, admin_user_path(order.user_id) %></p>
+      <% if order.packaged? %>
+        <%= button_to "Ship", "/admin/orders/ship/#{order.id}", method: :patch %>
+      <% end %>
     </div>
   <% end %>
 </section>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,12 +41,15 @@ Rails.application.routes.draw do
   namespace :admin do
     get '/dashboard', to: 'dashboard#index'
     get '/users/:user_id/orders', to: 'orders#index', as: :user_orders
+
+    patch '/orders/ship/:order_id', to: 'orders#ship', as: :order_ship
     patch '/users/upgrade/:user_id', to: 'users#upgrade', as: :user_upgrade
     patch '/merchants/downgrade/:merchant_id', to: 'merchants#downgrade', as: :merchant_downgrade
 
-    resources :merchants, only: [:update]
     post '/merchants/enable/:id', to: 'merchants#enable'
     post '/merchants/disable/:id', to: 'merchants#disable'
+
+    resources :merchants, only: [:update]
     resources :users, only: [:index, :show]
   end
 end

--- a/spec/features/admin/dashboard/index_spec.rb
+++ b/spec/features/admin/dashboard/index_spec.rb
@@ -139,6 +139,24 @@ RSpec.describe "as an admin" do
       end
     end
 
+    describe "and click 'Ship' beside an order name" do
+      it "the order is shipped" do
+        visit admin_dashboard_path
+
+        within ".order-#{@order_3.id}" do
+          click_button "Ship"
+
+          expect(@order_3.shipped?).to eq(true)
+        end
+
+        within ".order-#{@order_4.id}" do
+          click_button "Ship"
+
+          expect(@order_4.shipped?).to eq(true)
+        end
+      end
+    end
+
     describe "and click on a user's name" do
       it "I'm taken to that user's profile page" do
         visit admin_dashboard_path

--- a/spec/features/admin/dashboard/index_spec.rb
+++ b/spec/features/admin/dashboard/index_spec.rb
@@ -190,8 +190,3 @@ RSpec.describe "as an admin" do
     end
   end
 end
-
-# Then I see any "packaged" orders ready to ship.
-# Next to each order I see a button to "ship" the order.
-# When I click that button for an order, the status of that order changes to "shipped"
-# And the user can no longer "cancel" the order.

--- a/spec/features/admin/dashboard/index_spec.rb
+++ b/spec/features/admin/dashboard/index_spec.rb
@@ -119,6 +119,26 @@ RSpec.describe "as an admin" do
       end
     end
 
+    it "I see a link to 'Ship' orders that are packaged" do
+      visit admin_dashboard_path
+
+      within ".order-#{@order_3.id}" do
+        expect(page).to have_button("Ship")
+      end
+
+      within ".order-#{@order_4.id}" do
+        expect(page).to have_button("Ship")
+      end
+
+      within ".order-#{@order_2.id}" do
+        expect(page).to_not have_button("Ship")
+      end
+
+      within ".order-#{@order_6.id}" do
+        expect(page).to_not have_button("Ship")
+      end
+    end
+
     describe "and click on a user's name" do
       it "I'm taken to that user's profile page" do
         visit admin_dashboard_path
@@ -132,3 +152,8 @@ RSpec.describe "as an admin" do
     end
   end
 end
+
+# Then I see any "packaged" orders ready to ship.
+# Next to each order I see a button to "ship" the order.
+# When I click that button for an order, the status of that order changes to "shipped"
+# And the user can no longer "cancel" the order.

--- a/spec/features/admin/dashboard/index_spec.rb
+++ b/spec/features/admin/dashboard/index_spec.rb
@@ -146,14 +146,34 @@ RSpec.describe "as an admin" do
         within ".order-#{@order_3.id}" do
           click_button "Ship"
 
+          @order_3.reload
+
           expect(@order_3.shipped?).to eq(true)
         end
 
         within ".order-#{@order_4.id}" do
           click_button "Ship"
 
+          @order_4.reload
+
           expect(@order_4.shipped?).to eq(true)
         end
+      end
+
+      it "I see a flash message stating that the order was shipped" do
+        visit admin_dashboard_path
+
+        within ".order-#{@order_3.id}" do
+          click_button "Ship"
+        end
+
+        expect(page).to have_content("Order #{@order_3.id} shipped!")
+
+        within ".order-#{@order_4.id}" do
+          click_button "Ship"
+        end
+
+        expect(page).to have_content("Order #{@order_4.id} shipped!")
       end
     end
 

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Order, type: :model do
       @order_1 = @user_8.orders.create!(status: 3)
       @order_2 = @user_8.orders.create!(status: 2)
       @order_3 = @user_8.orders.create!(status: 0)
+      @order_4 = @user_8.orders.create!(status: 1)
 
       @order_item_1 = @order_1.order_items.create!(item_id: @item_1.id, quantity: 1, price: 1.00, fulfilled: true)
       @order_item_2 = @order_2.order_items.create!(item_id: @item_1.id, quantity: 1, price: 1.00, fulfilled: true)
@@ -84,6 +85,12 @@ RSpec.describe Order, type: :model do
       @order_item_5 = @order_2.order_items.create!(item_id: @item_2.id, quantity: 2, price: 4.00, fulfilled: true)
       @order_item_6 = @order_3.order_items.create!(item_id: @item_2.id, quantity: 2, price: 4.00, fulfilled: false)
       @order_item_7 = @order_3.order_items.create!(item_id: @item_2.id, quantity: 2, price: 4.00, fulfilled: true)
+    end
+
+    it "#ship" do
+      @order_4.ship
+
+      expect(@order_4.status).to eq("shipped")
     end
 
     it "#user_name" do


### PR DESCRIPTION
This PR adds a button to the Admin Dashboard index view that allows the Admin to 'Ship' an order.

- Add ship action to Admin OrdersController
- Add ship method and spec to Order model
- Add admin_order_ship path to routes