### PR TITLE
Merchant Items Index

### DIFF
--- a/app/controllers/merchants/items_controller.rb
+++ b/app/controllers/merchants/items_controller.rb
@@ -1,0 +1,37 @@
+class Merchants::ItemsController < ApplicationController
+  def index
+    if params[:id]
+      @merchant = User.find(params[:id])
+    else
+      @merchant = current_user
+    end
+
+    @dashboard = @merchant == current_user || current_admin? ? true : false
+
+    @items_left = []; @items_mid = []; @items_right = []
+
+    i = 0
+
+    @merchant.items.each do |item|
+      case i
+        when 0; @items_left << item
+        when 1; @items_mid << item
+        when 2; @items_right << item
+      end
+      i += 1; i = 0 if i > 2
+    end
+
+    @orders_left = []; @orders_mid = []; @orders_right = []
+
+    i = 0
+
+    @merchant.pending_orders.each do |order|
+      case i
+        when 0; @orders_left << order
+        when 1; @orders_mid << order
+        when 2; @orders_right << order
+      end
+      i += 1; i = 0 if i > 2
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -4,7 +4,7 @@ class SessionsController < ApplicationController
       if current_user.admin?
         redirect_to admin_dashboard_path(current_user)
       elsif current_user.merchant?
-        redirect_to dashboard_path(current_user)
+        redirect_to dashboard_path
       else
         redirect_to profile_path
       end

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,6 +1,6 @@
 <section>
   <h2><%= @user.name %></h2>
-  <%= button_to "Upgrade to Merchant", "/admin/users/upgrade/#{@user.id}", method: :patch %>
+  <%= button_to "Upgrade to Merchant", admin_user_upgrade_path(@user), method: :patch %>
 </section>
 
 <section class="user-profile-<%= @user.id %>">

--- a/app/views/merchants/items/index.html.erb
+++ b/app/views/merchants/items/index.html.erb
@@ -1,0 +1,103 @@
+<% if @dashboard %>
+  <div class="row clearfix">
+    <h4 class="left" style="margin-left: 10px">Your Items</h4>
+    <%= link_to "Add Item", new_item_path, class: "btn", style: "margin-top: 1.52rem; margin-left: 1.52rem" %>
+  </div>
+<% else %>
+  <h4>Items</h4>
+<% end %>
+<div class="row">
+  <div class="col s4">
+    <% @items_left.each do |item| %>
+      <div id="item-<%=item.id%>" class="card horizontal red">
+        <div class="card-image">
+          <%= link_to item_path(item) do %>
+            <%= image_tag item.image, {class: "item-#{item.id}-image", alt: "#{item.name}-image"} %>
+          <% end %>
+        </div>
+        <div class="card-stacked">
+          <div class="card-content">
+            <h5><%=item.name%></h5>
+            <p>
+              Avaliable: <%=item.inventory%><br>
+              Price: <%=number_to_currency(item.price)%>
+            </p>
+          </div>
+          <% if @dashboard %>
+            <div class="card-action center">
+              <%= link_to "Edit", edit_item_path(item) %>
+              <% if item.active %>
+                <%= link_to "Disable", "/items/disable/#{item.id}", method: :post %>
+              <% else %>
+                <%= link_to "Enable", "/items/enable/#{item.id}", method: :post %>
+              <% end %>
+              <%= link_to "Delete", item_path(item), method: :delete %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="col s4">
+    <% @items_mid.each do |item| %>
+      <div id="item-<%=item.id%>" class="card horizontal red">
+        <div class="card-image">
+          <%= link_to item_path(item) do %>
+            <%= image_tag item.image, {class: "item-#{item.id}-image", alt: "#{item.name}-image"} %>
+          <% end %>
+        </div>
+        <div class="card-stacked">
+          <div class="card-content">
+            <h5><%=item.name%></h5>
+            <p>
+              Avaliable: <%= item.inventory %><br>
+              Price: <%= number_to_currency(item.price) %>
+            </p>
+          </div>
+          <% if @dashboard %>
+            <div class="card-action center">
+              <%= link_to "Edit", edit_item_path(item) %>
+              <% if item.active %>
+                <%= link_to "Disable", "/items/disable/#{item.id}", method: :post %>
+              <% else %>
+                <%= link_to "Enable", "/items/enable/#{item.id}", method: :post %>
+              <% end %>
+              <%= link_to "Delete", item_path(item), method: :delete %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="col s4">
+    <% @items_right.each do |item| %>
+      <div id="item-<%= item.id %>" class="card horizontal red">
+        <div class="card-image">
+          <%= image_tag item.image, {class: "item-#{item.id}-image", alt: "#{item.name}-image"} %>
+        </div>
+        <div class="card-stacked">
+          <div class="card-content">
+            <h5><%= item.name %></h5>
+            <p>
+              Avaliable: <%= item.inventory %><br>
+              Price: <%= number_to_currency(item.price) %>
+            </p>
+          </div>
+          <% if @dashboard %>
+            <div class="card-action center">
+              <%= link_to "Edit", edit_item_path(item) %>
+              <% if item.active %>
+                <%= link_to "Disable", "/items/disable/#{item.id}", method: :post %>
+              <% else %>
+                <%= link_to "Enable", "/items/enable/#{item.id}", method: :post %>
+              <% end %>
+              <%= link_to "Delete", item_path(item), method: :delete %>
+            </div>
+          <% end %>
+        </div>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -10,7 +10,7 @@
 <%= link_to "Edit my Profile", profile_edit_path, class: "btn", style: "margin-bottom: 2rem" if @dashboard %>
 
 <% if current_admin? %>
-  <%= button_to "Downgrade to User", admin_merchant_downgrade_path(@merchant.id), method: :patch, class: "btn" %>
+  <%= button_to "Downgrade to User", admin_merchant_downgrade_path(@merchant), method: :patch, class: "btn" %>
 <% end %>
 
 <% if @dashboard %>

--- a/app/views/merchants/show.html.erb
+++ b/app/views/merchants/show.html.erb
@@ -8,6 +8,7 @@
 </p>
 
 <%= link_to "Edit my Profile", profile_edit_path, class: "btn", style: "margin-bottom: 2rem" if @dashboard %>
+<%= link_to "View All Items", merchant_dashboard_items_path, class: "btn", style: "margin-bottom: 2rem"%>
 
 <% if current_admin? %>
   <%= button_to "Downgrade to User", admin_merchant_downgrade_path(@merchant), method: :patch, class: "btn" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,9 @@ Rails.application.routes.draw do
   delete '/logout', to: "sessions#delete"
 
   get '/dashboard', to: "merchants#show"
+  get '/dashboard/items', to: 'merchants/items#index', as: :merchant_dashboard_items
   get '/dashboard/orders/:id', to: 'merchants/orders#show', as: :merchant_order
+
   patch "/merchants/orders/fulfill/:id", to: 'merchants/orders#fulfill'
 
   namespace :admin do

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -1,10 +1,3 @@
-
-# I see all merchants in the system
-# Next to each merchant's name I see their city and state
-# The merchant's name is a link to their Merchant Dashboard at routes such as "/admin/merchants/5"
-# I see a "disable" button next to any merchants who are not yet disabled
-# I see an "enable" button next to any merchants whose accounts are disabled
-
 require 'rails_helper'
 
 describe "as an admin" do
@@ -18,61 +11,76 @@ describe "as an admin" do
       visit root_path
 
       click_on "Login"
+
       fill_in "email", with: @admin_1.email
       fill_in "password", with: @admin_1.password
+
       click_on "Log In"
     end
 
     it "it displays all merchants" do
       visit merchants_path
+
       within "#merchant-#{@merchant_1.id}" do
         expect(page).to have_link(@merchant_1.name)
         expect(page).to have_content(@merchant_1.city)
         expect(page).to have_content(@merchant_1.state)
         expect(page).to have_link("Disable")
       end
+
       within "#merchant-#{@merchant_2.id}" do
         expect(page).to have_link(@merchant_2.name)
         expect(page).to have_content(@merchant_2.city)
         expect(page).to have_content(@merchant_2.state)
         expect(page).to have_link("Enable")
       end
-
     end
 
     it "lets an admin know if a merchant was enabled/disabled" do
       visit merchants_path
+
       within "#merchant-#{@merchant_2.id}" do
         click_link "Enable"
       end
-        expect(current_path).to eq(merchants_path)
-        expect(page).to have_content("Merchant has been enabled.")
-        @merchant_2.reload
-        expect(@merchant_2.active).to eq(true)
-        within "#merchant-#{@merchant_2.id}" do
-          click_link "Disable"
-        end
-        expect(current_path).to eq(merchants_path)
-        expect(page).to have_content("Merchant has been disabled.")
-        expect(User.find(@merchant_2.id).active).to eq(false)
+
+      expect(current_path).to eq(merchants_path)
+      expect(page).to have_content("Merchant has been enabled.")
+
+      @merchant_2.reload
+
+      expect(@merchant_2.active).to eq(true)
+
+      within "#merchant-#{@merchant_2.id}" do
+        click_link "Disable"
+      end
+
+      expect(current_path).to eq(merchants_path)
+      expect(page).to have_content("Merchant has been disabled.")
+      expect(User.find(@merchant_2.id).active).to eq(false)
     end
 
     it "only lets enabled users log in" do
       click_on "Logout"
+
       click_on "Login"
+
       fill_in "email", with: @merchant_1.email
       fill_in "password", with: @merchant_1.password
+
       click_on "Log In"
-      expect(current_path).to eq(dashboard_path(@merchant_1))
+
+      expect(current_path).to eq(dashboard_path)
+
       click_on "Logout"
+
       click_on "Login"
+
       fill_in "email", with: @merchant_2.email
       fill_in "password", with: @merchant_2.password
+
       click_on "Log In"
+
       expect(current_path).to eq(login_path)
-
     end
-
   end
-
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -1,0 +1,65 @@
+require 'rails_helper'
+
+RSpec.describe "as a merchant" do
+  describe "when I visit my item index page" do
+    before :each do
+      @merchant = User.create!(email: "merchant@gmail.com", role: 1, active: true, name: "Merchant", address: "Merchant Address", city: "Merchant City", state: "Merchant State", zip: "22345", password: "123456")
+
+      @item_1 = @merchant.items.create!(name: "Item 1", active: true, price: 1.00, description: "Item 1 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 10)
+      @item_2 = @merchant.items.create!(name: "Item 2", active: false, price: 2.00, description: "Item 2 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 15)
+      @item_3 = @merchant.items.create!(name: "Item 3", active: true, price: 3.00, description: "Item 3 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 20)
+      @item_4 = @merchant.items.create!(name: "Item 4", active: true, price: 4.00, description: "Item 4 Description", image: "https://tradersofafrica.com/img/no-product-photo.jpg", inventory: 25)
+
+      visit root_path
+
+      click_link "Login"
+
+      fill_in 'email', with: @merchant.email
+      fill_in 'password', with: @merchant.password
+
+      click_button "Log In"
+
+      click_link "Dashboard"
+
+      click_link "View All Items"
+    end
+
+    it "it displays all my items" do
+      within "#item-#{@item_1.id}" do
+        expect(page).to have_content(@item_1.name)
+        expect(page).to have_content(@item_1.inventory)
+        expect(page).to have_content("Edit")
+        expect(page).to have_content("Disable")
+        expect(page).to_not have_content("Enable")
+        expect(page).to have_content("Delete")
+      end
+
+      within "#item-#{@item_2.id}" do
+        expect(page).to have_content(@item_2.name)
+        expect(page).to have_content(@item_2.inventory)
+        expect(page).to have_content("Edit")
+        expect(page).to_not have_content("Disable")
+        expect(page).to have_content("Enable")
+        expect(page).to have_content("Delete")
+      end
+      save_and_open_page
+      within "#item-#{@item_3.id}" do
+        expect(page).to have_content(@item_3.name)
+        expect(page).to have_content(@item_3.inventory)
+        expect(page).to have_content("Edit")
+        expect(page).to have_content("Disable")
+        expect(page).to_not have_content("Enable")
+        expect(page).to have_content("Delete")
+      end
+
+      within "#item-#{@item_4.id}" do
+        expect(page).to have_content(@item_4.name)
+        expect(page).to have_content(@item_4.inventory)
+        expect(page).to have_content("Edit")
+        expect(page).to have_content("Disable")
+        expect(page).to_not have_content("Enable")
+        expect(page).to have_content("Delete")
+      end
+    end
+  end
+end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -61,5 +61,53 @@ RSpec.describe "as a merchant" do
         expect(page).to have_content("Delete")
       end
     end
+
+    it "I can edit an item" do
+      within "#item-#{@item_1.id}" do
+        click_on "Edit"
+      end
+
+      expect(current_path).to eq(edit_item_path(@item_1))
+
+      fill_in "item[name]", with: "Updated Item 1"
+
+      click_on "Update Item"
+
+      expect(current_path).to eq(dashboard_path)
+
+      expect(page).to have_content("Item updated.")
+
+      within "#item-#{@item_1.id}" do
+        expect(page).to have_content("Updated Item 1")
+      end
+    end
+
+    it "can enable/disable items" do
+      within "#item-#{@item_1.id}" do
+        click_on "Disable"
+      end
+
+      expect(current_path).to eq(dashboard_path)
+
+      expect(page).to have_content("Item has been disabled.")
+
+      within "#item-#{@item_1.id}" do
+        expect(page).to have_content("Enable")
+        expect(page).to_not have_content("Disable")
+      end
+
+      within "#item-#{@item_1.id}" do
+        click_on "Enable"
+      end
+
+      expect(current_path).to eq(dashboard_path)
+
+      expect(page).to have_content("Item has been enabled.")
+
+      within "#item-#{@item_1.id}" do
+        expect(page).to have_content("Disable")
+        expect(page).to_not have_content("Enable")
+      end
+    end
   end
 end

--- a/spec/features/merchants/items/index_spec.rb
+++ b/spec/features/merchants/items/index_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe "as a merchant" do
         expect(page).to have_content("Enable")
         expect(page).to have_content("Delete")
       end
-      save_and_open_page
+
       within "#item-#{@item_3.id}" do
         expect(page).to have_content(@item_3.name)
         expect(page).to have_content(@item_3.inventory)
@@ -82,7 +82,7 @@ RSpec.describe "as a merchant" do
       end
     end
 
-    it "can enable/disable items" do
+    it "I can enable/disable items" do
       within "#item-#{@item_1.id}" do
         click_on "Disable"
       end
@@ -108,6 +108,18 @@ RSpec.describe "as a merchant" do
         expect(page).to have_content("Disable")
         expect(page).to_not have_content("Enable")
       end
+    end
+
+    it "I can delete an item" do
+      within "#item-#{@item_1.id}" do
+        click_on "Delete"
+      end
+
+      expect(current_path).to eq(dashboard_path)
+
+      expect(page).to have_content("Item has been deleted.")
+
+      expect(page).to_not have_content(@item_1.name)
     end
   end
 end

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -168,7 +168,7 @@ describe "as a merchant" do
       end
     end
 
-    it "can edit an item" do
+    it "can delete an item" do
       visit root_path
 
       click_link "Login"

--- a/spec/features/merchants/show_spec.rb
+++ b/spec/features/merchants/show_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+
 describe "as a merchant" do
   describe "when I visit my dashboard page" do
     before :each do
@@ -33,14 +34,18 @@ describe "as a merchant" do
 
     it "does not display for visitors or users" do
       visit root_path
+
       expect(page).to have_no_link("Dashboard")
 
       click_link "Login"
+
       fill_in 'email', with: @user1.email
       fill_in 'password', with: @user1.password
+
       click_button "Log In"
 
       visit root_path
+
       expect(page).to have_no_link("Dashboard")
     end
 
@@ -48,12 +53,14 @@ describe "as a merchant" do
       visit root_path
 
       click_link "Login"
+
       fill_in 'email', with: @merchant.email
       fill_in 'password', with: @merchant.password
 
       click_button "Log In"
 
       click_link "Dashboard"
+
       expect(current_path).to eq(dashboard_path)
 
       expect(page).to have_content(@merchant.name)
@@ -61,9 +68,6 @@ describe "as a merchant" do
       expect(page).to have_content(@merchant.address)
       expect(page).to have_content(@merchant.city)
       expect(page).to have_content(@merchant.state)
-      
-
-
 
       within "#item-#{@itemA.id}" do
         expect(page).to have_content(@itemA.name)
@@ -104,17 +108,22 @@ describe "as a merchant" do
       click_button "Log In"
 
       click_link "Dashboard"
+
       expect(current_path).to eq(dashboard_path)
 
       within "#item-#{@itemA.id}" do
         click_on "Edit"
       end
+
       expect(current_path).to eq("/items/#{@itemA.id}/edit")
+
       fill_in 'item[name]', with: "ItemAHHHH"
+
       click_on "Update Item"
 
       expect(current_path).to eq('/dashboard')
       expect(page).to have_content("Item updated.")
+
       within "#item-#{@itemA.id}" do
         expect(page).to have_content("ItemAHHHH")
       end
@@ -124,11 +133,14 @@ describe "as a merchant" do
       visit root_path
 
       click_link "Login"
+
       fill_in 'email', with: @merchant.email
       fill_in 'password', with: @merchant.password
+
       click_button "Log In"
 
       click_link "Dashboard"
+
       expect(current_path).to eq(dashboard_path)
 
       within "#item-#{@itemA.id}" do
@@ -137,6 +149,7 @@ describe "as a merchant" do
 
       expect(current_path).to eq('/dashboard')
       expect(page).to have_content("Item has been disabled.")
+
       within "#item-#{@itemA.id}" do
         expect(page).to_not have_content("Disable")
         expect(page).to have_content("Enable")
@@ -148,6 +161,7 @@ describe "as a merchant" do
 
       expect(current_path).to eq('/dashboard')
       expect(page).to have_content("Item has been enabled.")
+
       within "#item-#{@itemA.id}" do
         expect(page).to_not have_content("Enable")
         expect(page).to have_content("Disable")
@@ -158,11 +172,14 @@ describe "as a merchant" do
       visit root_path
 
       click_link "Login"
+
       fill_in 'email', with: @merchant.email
       fill_in 'password', with: @merchant.password
+
       click_button "Log In"
 
       click_link "Dashboard"
+
       expect(current_path).to eq(dashboard_path)
 
       within "#item-#{@itemA.id}" do
@@ -176,10 +193,14 @@ describe "as a merchant" do
 
     it "displays a list of pending orders that contain merchant items" do
       visit root_path
+
       click_link "Login"
+
       fill_in 'email', with: @merchant_1.email
       fill_in 'password', with: @merchant_1.password
+
       click_button "Log In"
+
       expect(page).to have_content(@order_1.id)
       expect(page).to have_content(@order_1.created_at.to_formatted_s(:long).slice(0...-6))
       expect(page).to have_content(@order_1.total_item_count)
@@ -191,6 +212,25 @@ describe "as a merchant" do
       # DONT FORGET TO TURN THE ORDER.ID INTO A BUTTON OR LINK AND TEST FOR IT!
       # click_link "#{@order_1.id}"
       # expect(current_path).to eq(merchant_order_path(@order_1))
+    end
+
+    it "I see a link to view my items" do
+      visit root_path
+
+      click_link "Login"
+
+      fill_in 'email', with: @merchant_1.email
+      fill_in 'password', with: @merchant_1.password
+
+      click_button "Log In"
+
+      click_link "Dashboard"
+
+      expect(page).to have_link("View All Items")
+
+      click_link("View All Items")
+
+      expect(current_path).to eq(merchant_dashboard_items_path)
     end
 
     describe "merchant statistics" do


### PR DESCRIPTION
This PR adds a 'View All Items' link to Merchant dashboards, as well as a Merchant Items index page.

- Add 'View All Items' link to Merchant dashboard view
- Copy Merchant Items HTML from dashboard to Items index
- Add Merchant Items index feature specs
- Copy Merchant show IVARS to Merchant Items index